### PR TITLE
Bumped minimum supported PHP version to 8.0

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Glob-like file and pattern matching utility.
 Requirements
 ------------
 
-  - [PHP](https://www.php.net/) >= 7.4
+  - [PHP](https://www.php.net/) >= 8.0
 
 Installation
 ------------

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "symfony/finder": "^5.0 || ^6.0"
+        "php": ">=8.0",
+        "symfony/finder": "^6.0"
     },
     "require-dev": {
         "phlak/coding-standards": "^2.0",
-        "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^8.0 || ^9.0",
-        "psy/psysh": "^0.10 || ^0.11",
-        "symfony/var-dumper": "^5.0",
+        "phpstan/phpstan": "^1.9",
+        "phpunit/phpunit": "^9.0",
+        "psy/psysh": "^0.11",
+        "symfony/var-dumper": "^6.0",
         "yoast/phpunit-polyfills": "^1.0"
     },
     "autoload": {

--- a/src/Pattern.php
+++ b/src/Pattern.php
@@ -16,9 +16,6 @@ class Pattern
     /** @const Add start and end anchors (i.e. '/^...$/') */
     public const BOTH_ANCHORS = self::START_ANCHOR | self::END_ANCHOR;
 
-    /** @var string The glob pattern */
-    protected $pattern;
-
     /** @var string The directory separator */
     protected static $directorySeparator = DIRECTORY_SEPARATOR;
 
@@ -26,9 +23,9 @@ class Pattern
     private $cache = [];
 
     /** Create a new object. */
-    public function __construct(string $pattern)
-    {
-        $this->pattern = $pattern;
+    public function __construct(
+        private string $pattern
+    ) {
     }
 
     /** Return the pattern as a string. */


### PR DESCRIPTION
With [PHP 7.4 now end-of-life](https://www.php.net/supported-versions.php) we can bump the minimum required PHP version to 8.0.