### PR TITLE
Fix handling of glob wildcards when inside a character class

### DIFF
--- a/src/Pattern.php
+++ b/src/Pattern.php
@@ -81,16 +81,24 @@ class Pattern
                     break;
 
                 case '?':
-                    $pattern .= '.';
+                    if ($characterGroup > 0) {
+                        $pattern .= $char;
+                    } else {
+                        $pattern .= '.';
+                    }
 
                     break;
 
                 case '*':
-                    if (isset($this->pattern[$i + 1]) && $this->pattern[$i + 1] === '*') {
-                        $pattern .= '.*';
-                        ++$i;
+                    if ($characterGroup > 0) {
+                        $pattern .= $char;
                     } else {
-                        $pattern .= sprintf('[^%s]*', addslashes(static::$directorySeparator));
+                        if (isset($this->pattern[$i + 1]) && $this->pattern[$i + 1] === '*') {
+                            $pattern .= '.*';
+                            ++$i;
+                        } else {
+                            $pattern .= sprintf('[^%s]*', addslashes(static::$directorySeparator));
+                        }
                     }
 
                     break;

--- a/tests/GlobTest.php
+++ b/tests/GlobTest.php
@@ -94,7 +94,7 @@ class GlobTest extends TestCase
         $this->assertFalse(Glob::match('[a-c][a-c]', 'abc'));
     }
 
-    public function test_it_mathes_any_character_not_in_a_set(): void
+    public function test_it_matches_any_character_not_in_a_set(): void
     {
         $this->assertTrue(Glob::match('[^abc]', 'x'));
         $this->assertTrue(Glob::match('[^abc]', 'z'));

--- a/tests/GlobTest.php
+++ b/tests/GlobTest.php
@@ -94,6 +94,14 @@ class GlobTest extends TestCase
         $this->assertFalse(Glob::match('[a-c][a-c]', 'abc'));
     }
 
+    public function test_it_matches_glob_wildcards_literally_in_character_classes(): void
+    {
+        $this->assertTrue(Glob::match('[*?**]', '*'));
+        $this->assertTrue(Glob::match('[*?**]', '?'));
+        $this->assertFalse(Glob::match('[*?**]', '.'));
+        $this->assertFalse(Glob::match('[*?**]', 'x'));
+    }
+
     public function test_it_matches_any_character_not_in_a_set(): void
     {
         $this->assertTrue(Glob::match('[^abc]', 'x'));

--- a/tests/PatternTest.php
+++ b/tests/PatternTest.php
@@ -42,6 +42,12 @@ class PatternTest extends TestCase
         $this->assertEquals('#^\\#$#', Pattern::make('\#')->toRegex());
     }
 
+    public function test_it_does_not_replace_glob_wildcards_in_character_classes(): void
+    {
+        $this->assertEquals('#^[\*\?\*\*]$#', Pattern::make('[\*\?\*\*]')->toRegex());
+        $this->assertEquals('#^[*?**]$#', Pattern::make('[*?**]')->toRegex());
+    }
+
     public function test_it_can_convert_a_complex_glob_pattern_to_a_regular_expressions(): void
     {
         $this->assertEquals('#^foo\.txt$#', Pattern::make('foo.txt')->toRegex());


### PR DESCRIPTION
`?` and `*` wildcards get replaced with `.` and `.*` respectively. Though, currently they are also replaced when inside a character class, so we end up with `[.]` and `[.*]` respectively.

This PR fixes cases like:
```php
Glob::match('[abc?def]', '?'); // expected: true, current: false
Glob::match('[abc?def]', '.'); // expected: false, current: true
Glob::match('[abc*def]', '.'); // expected: false, current: true
```