### PR TITLE
Improved code for supporting special characters in ranges

### DIFF
--- a/src/Pattern.php
+++ b/src/Pattern.php
@@ -63,27 +63,28 @@ class Pattern
             return $this->cache[$options];
         }
 
+        $length = strlen($this->pattern);
         $pattern = '';
-        $characterGroup = false;
-        $lookaheadGroup = 0;
+        $inCharacterGroup = false;
         $patternGroup = 0;
+        $lookaheadGroup = 0;
 
-        for ($i = 0; $i < strlen($this->pattern); ++$i) {
+        for ($i = 0; $i < $length; ++$i) {
             $char = $this->pattern[$i];
 
             switch ($char) {
                 case '\\':
-                    $pattern .= $characterGroup ? '\\\\' : '\\' . $this->pattern[++$i];
+                    $pattern .= $inCharacterGroup ? '\\\\' : '\\' . $this->pattern[++$i];
 
                     break;
 
                 case '?':
-                    $pattern .= $characterGroup ? $char : '.';
+                    $pattern .= $inCharacterGroup ? $char : '.';
 
                     break;
 
                 case '*':
-                    if ($characterGroup) {
+                    if ($inCharacterGroup) {
                         $pattern .= $char;
 
                         break;
@@ -105,13 +106,13 @@ class Pattern
 
                 case '[':
                     $pattern .= $char;
-                    $characterGroup = true;
+                    $inCharacterGroup = true;
 
                     break;
 
                 case ']':
-                    if ($characterGroup) {
-                        $characterGroup = false;
+                    if ($inCharacterGroup) {
+                        $inCharacterGroup = false;
                     }
 
                     $pattern .= $char;
@@ -119,7 +120,7 @@ class Pattern
                     break;
 
                 case '^':
-                    $pattern .= $characterGroup ? $char : '\\' . $char;
+                    $pattern .= $inCharacterGroup ? $char : '\\' . $char;
 
                     break;
 
@@ -131,7 +132,7 @@ class Pattern
 
                 case '}':
                     if ($patternGroup > 0) {
-                        $pattern .= $characterGroup ? $char : ')';
+                        $pattern .= $inCharacterGroup ? $char : ')';
                         --$patternGroup;
                     } else {
                         $pattern .= $char;
@@ -141,7 +142,7 @@ class Pattern
 
                 case ',':
                     if ($patternGroup > 0) {
-                        $pattern .= $characterGroup ? $char : '|';
+                        $pattern .= $inCharacterGroup ? $char : '|';
                     } else {
                         $pattern .= $char;
                     }
@@ -153,7 +154,7 @@ class Pattern
                         $pattern .= sprintf('(?%s', $this->pattern[++$i]);
                         ++$lookaheadGroup;
                     } else {
-                        $pattern .= $characterGroup ? $char : '\\' . $char;
+                        $pattern .= $inCharacterGroup ? $char : '\\' . $char;
                     }
 
                     break;
@@ -163,14 +164,14 @@ class Pattern
                         --$lookaheadGroup;
                         $pattern .= $char;
                     } else {
-                        $pattern .= $characterGroup ? $char : '\\' . $char;
+                        $pattern .= $inCharacterGroup ? $char : '\\' . $char;
                     }
 
                     break;
 
                 default:
                     if (in_array($char, ['.', '|', '+', '$'])) {
-                        $pattern .= $characterGroup ? $char : '\\' . $char;
+                        $pattern .= $inCharacterGroup ? $char : '\\' . $char;
                     } else {
                         $pattern .= $char;
                     }

--- a/tests/GlobTest.php
+++ b/tests/GlobTest.php
@@ -96,10 +96,9 @@ class GlobTest extends TestCase
 
     public function test_it_matches_glob_wildcards_literally_in_character_classes(): void
     {
-        $this->assertTrue(Glob::match('[[?*\]', '?'));
-        $this->assertTrue(Glob::match('[[?*\]', '*'));
-        $this->assertTrue(Glob::match('[[?*\]', '\\'));
-        $this->assertFalse(Glob::match('[[?*\]', 'x'));
+        $this->assertTrue(Glob::match('[[?*]', '?'));
+        $this->assertTrue(Glob::match('[[?*]', '*'));
+        $this->assertFalse(Glob::match('[[?*]', 'x'));
     }
 
     public function test_it_matches_any_character_not_in_a_set(): void

--- a/tests/PatternTest.php
+++ b/tests/PatternTest.php
@@ -53,8 +53,6 @@ class PatternTest extends TestCase
         $this->assertEquals('#^file\.(yml|yaml)$#', Pattern::make('file.{yml,yaml}')->toRegex());
         $this->assertEquals('#^[fbw]oo\.txt$#', Pattern::make('[fbw]oo.txt')->toRegex());
         $this->assertEquals('#^[^fbw]oo\.txt$#', Pattern::make('[^fbw]oo.txt')->toRegex());
-        $this->assertEquals('#^[[?*\\\\]$#', Pattern::make('[[?*\]')->toRegex());
-        $this->assertEquals('#^[.\\\\]$#', Pattern::make('[.\]')->toRegex());
         $this->assertEquals('#^foo}bar\.txt$#', Pattern::make('foo}bar.txt')->toRegex());
         $this->assertEquals('#^foo\^bar\.txt$#', Pattern::make('foo^bar.txt')->toRegex());
         $this->assertEquals('#^foo,bar\.txt$#', Pattern::make('foo,bar.txt')->toRegex());


### PR DESCRIPTION
Follow-up to #9.

With this new code, all special characters can be used in ranges without having to be escaped.

Basically, it's a new approach that uses two different code paths, whether we are in a character range or not. It's both simpler and robuster.

Notes:
* An unescaped `\` at the end of the pattern was previously triggering a PHP warning, and unexpectedly escaping the next character appended after the loop (`$` end anchor or `#` pattern delimiter). In the revised code, I drop out this `\`, and trigger the same PHP warning for BC.
* As in previous code, an unescaped `\` at the end of a character range is not supported (and should not be), and PHP triggers a "preg_match(): compilation failed" warning (because the `\` escapes the `]`, so the character range isn't closed).

Disclaimer: published "in emergency" after #9 got merged. Though, everything is working.